### PR TITLE
Add a prelude

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,3 +11,7 @@ pub mod spim;
 pub mod gpio;
 pub mod clocks;
 pub mod time;
+
+pub mod prelude {
+    pub use hal::prelude::*;
+}


### PR DESCRIPTION
So far, it just re-exports the embedded-hal prelude. This is convenient
for users that depend on nrf52-hal, but wouldn't otherwise need to
depend on embedded-hal.

@jamesmunns This is a minor and probably uncontroversial change. Please let me know how you want to handle these kind of things in the future. If you want to review and approve everything, that would be ideal from a quality perspective. But if you don't have the time for that, I can merge small changes that I don't require feedback on myself.